### PR TITLE
Fixed typo in DeclareWar, fixed condition for no faction membership needed

### DIFF
--- a/src/main/java/factionsplusplus/commands/DeclareWarCommand.java
+++ b/src/main/java/factionsplusplus/commands/DeclareWarCommand.java
@@ -48,7 +48,7 @@ public class DeclareWarCommand extends Command {
     ) {
         super(
             new CommandBuilder()
-                .withName("grantindependence")
+                .withName("declarewar")
                 .withAliases("dw", LOCALE_PREFIX + "CmdDeclareWar")
                 .withDescription("Declare war on a faction.")
                 .requiresPermissions("mf.declarewar")

--- a/src/main/java/factionsplusplus/services/CommandService.java
+++ b/src/main/java/factionsplusplus/services/CommandService.java
@@ -208,7 +208,7 @@ public class CommandService implements TabCompleter {
             }
         }
 
-        if (command.shouldRequireNoFactionMembership()) {
+        if (! command.shouldRequireNoFactionMembership()) {
             if (playerFaction != null) {
                 context.replyWith("AlertAlreadyInFaction");
                 return false;
@@ -352,7 +352,7 @@ public class CommandService implements TabCompleter {
                         if (onlinePlayer != null) {
                             parsedArgumentData = onlinePlayer;
                             break;
-                        }            
+                        }
                         context.replyWith(
                             new MessageBuilder("PlayerNotFound")
                                 .with("name", argumentData)
@@ -592,7 +592,7 @@ public class CommandService implements TabCompleter {
                 if (
                     this.senderCanAccessCommand(sender, commandObj) &&
                     commandObj.getName().toLowerCase().startsWith(nextArg.toLowerCase())
-                ) { 
+                ) {
                     results.add(commandObj.getName().toLowerCase());
                 }
             }


### PR DESCRIPTION
There is an issue during `/f declarewar "faction" "reason"`, it seems to be grabbing the full args (`faction" "reason`) sent during `getAnyFaction` https://github.com/nortoh/FactionsPlusPlus/blob/5030f8920f6517159fe22f232b11d3509c29ab67/src/main/java/factionsplusplus/services/CommandService.java#L312