### PR TITLE
Check if context is null

### DIFF
--- a/src/main/java/factionsplusplus/eventhandlers/InteractionHandler.java
+++ b/src/main/java/factionsplusplus/eventhandlers/InteractionHandler.java
@@ -202,7 +202,7 @@ public class InteractionHandler implements Listener {
     public void handle(PlayerInteractEvent event) {
         // Ignore events for offhand
         if (event.getHand() == EquipmentSlot.OFF_HAND) return;
-        
+
         Player player = event.getPlayer();
 
         Block clickedBlock = event.getClickedBlock();
@@ -211,7 +211,7 @@ public class InteractionHandler implements Listener {
         }
 
         InteractionContext context = this.ephemeralData.getPlayersPendingInteraction().get(player.getUniqueId());
-        
+
         if (context != null) {
             if (context.isLockedBlockLock()) this.lockService.handleLockingBlock(event, player, clickedBlock);
             if (context.isLockedBlockUnlock()) this.lockService.handleUnlockingBlock(event, player, clickedBlock);
@@ -274,8 +274,8 @@ public class InteractionHandler implements Listener {
         if (chunk != null) {
             this.claimService.handleClaimedChunkInteraction(event, chunk);
         }
-        
-        if (context.isGateCreating() && playerHoldingGoldenHoe(player)) {
+
+        if (context != null && context.isGateCreating() && playerHoldingGoldenHoe(player)) {
             gateService.handleCreatingGate(clickedBlock, player, event);
         }
     }


### PR DESCRIPTION
This was appearing in my terminal

```[00:47:44] [Server thread/ERROR]: Could not pass event PlayerInteractEvent to FactionsPlusPlus v1.0.0-SNAPSHOT
java.lang.NullPointerException: Cannot invoke "factionsplusplus.models.InteractionContext.isGateCreating()" because "context" is null
	at factionsplusplus.eventhandlers.InteractionHandler.handle(InteractionHandler.java:278) ~[FactionsPlusPlus-1.0.0-SNAPSHOT.jar:?]
	at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor40.execute(Unknown Source) ~[?:?]
	at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:75) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:git-Paper-211]
	at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:670) ~[paper-api-1.19.2-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_19_R1.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:545) ~[paper-1.19.2.jar:git-Paper-211]
	at net.minecraft.server.level.ServerPlayerGameMode.useItemOn(ServerPlayerGameMode.java:526) ~[?:?]
	at net.minecraft.server.network.ServerGamePacketListenerImpl.handleUseItemOn(ServerGamePacketListenerImpl.java:1969) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.handle(ServerboundUseItemOnPacket.java:37) ~[?:?]
	at net.minecraft.network.protocol.game.ServerboundUseItemOnPacket.a(ServerboundUseItemOnPacket.java:9) ~[?:?]
	at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$1(PacketUtils.java:51) ~[?:?]
	at net.minecraft.server.TickTask.run(TickTask.java:18) ~[paper-1.19.2.jar:git-Paper-211]
	at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:153) ~[?:?]
	at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[?:?]
	at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1341) ~[paper-1.19.2.jar:git-Paper-211]
	at net.minecraft.server.MinecraftServer.d(MinecraftServer.java:185) ~[paper-1.19.2.jar:git-Paper-211]
	at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:126) ~[?:?]
	at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1318) ~[paper-1.19.2.jar:git-Paper-211]
	at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1311) ~[paper-1.19.2.jar:git-Paper-211]
	at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:136) ~[?:?]
	at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1289) ~[paper-1.19.2.jar:git-Paper-211]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1177) ~[paper-1.19.2.jar:git-Paper-211]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:305) ~[paper-1.19.2.jar:git-Paper-211]
	at java.lang.Thread.run(Unknown Source) ~[?:?]```
	
	