### PR TITLE
Specify column id in foreign constraints

### DIFF
--- a/src/main/java/factionsplusplus/services/DataService.java
+++ b/src/main/java/factionsplusplus/services/DataService.java
@@ -114,8 +114,8 @@ public class DataService {
                     flag_name CHAR(255) NOT NULL,
                     `value` VARCHAR(255),
                     PRIMARY KEY(faction_id, flag_name),
-                    FOREIGN KEY(faction_id) REFERENCES factions (id) ON DELETE CASCADE,
-                    FOREIGN KEY(flag_name) REFERENCES default_flags (name) ON DELETE CASCADE
+                    FOREIGN KEY(faction_id) REFERENCES factions(id) ON DELETE CASCADE,
+                    FOREIGN KEY(flag_name) REFERENCES default_flags(name) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -130,8 +130,8 @@ public class DataService {
                     flag_name CHAR(255) NOT NULL,
                     `value` VARCHAR(255),
                     PRIMARY KEY(world_id, flag_name),
-                    FOREIGN KEY(world_id) REFERENCES worlds (id) ON DELETE CASCADE,
-                    FOREIGN KEY(flag_name) REFERENCES default_flags (name) ON DELETE CASCADE
+                    FOREIGN KEY(world_id) REFERENCES worlds(id) ON DELETE CASCADE,
+                    FOREIGN KEY(flag_name) REFERENCES default_flags(name) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -151,8 +151,8 @@ public class DataService {
                     player_id BINARY(16) NOT NULL,
                     role INTEGER NOT NULL DEFAULT 1,
                     PRIMARY KEY(faction_id, player_id),
-                    FOREIGN KEY(faction_id) REFERENCES factions (id) ON DELETE CASCADE,
-                    FOREIGN KEY(player_id) REFERENCES players (id) ON DELETE CASCADE
+                    FOREIGN KEY(faction_id) REFERENCES factions(id) ON DELETE CASCADE,
+                    FOREIGN KEY(player_id) REFERENCES players(id) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -162,8 +162,8 @@ public class DataService {
                     x_position INTEGER NOT NULL,
                     z_position INTEGER NOT NULL,
                     PRIMARY KEY(world_id, x_position, z_position),
-                    FOREIGN KEY(faction_id) REFERENCES factions (id) ON DELETE CASCADE,
-                    FOREIGN KEY(world_id) REFERENCES worlds (id) ON DELETE CASCADE
+                    FOREIGN KEY(faction_id) REFERENCES factions(id) ON DELETE CASCADE,
+                    FOREIGN KEY(world_id) REFERENCES worlds(id) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -176,8 +176,8 @@ public class DataService {
                     ended_at DATETIME,
                     is_active BOOLEAN NOT NULL DEFAULT 1,
                     PRIMARY KEY(id),
-                    FOREIGN KEY(attacker_id) REFERENCES factions (id) ON DELETE CASCADE,
-                    FOREIGN KEY(defender_id) REFERENCES factions (id) ON DELETE CASCADE
+                    FOREIGN KEY(attacker_id) REFERENCES factions(id) ON DELETE CASCADE,
+                    FOREIGN KEY(defender_id) REFERENCES factions(id) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -192,8 +192,8 @@ public class DataService {
                     allow_faction_members BOOLEAN NOT NULL DEFAULT 0,
                     PRIMARY KEY(id),
                     UNIQUE KEY UNIQUE_POSITION (world_id, x_position, y_position, z_position),
-                    FOREIGN KEY(world_id) REFERENCES worlds (id) ON DELETE CASCADE,
-                    FOREIGN KEY(player_id) REFERENCES players (id) ON DELETE CASCADE
+                    FOREIGN KEY(world_id) REFERENCES worlds(id) ON DELETE CASCADE,
+                    FOREIGN KEY(player_id) REFERENCES players(id) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -201,8 +201,8 @@ public class DataService {
                     locked_block_id BINARY(16) NOT NULL,
                     player_id BINARY(16) NOT NULL,
                     PRIMARY KEY (locked_block_id, player_id),
-                    FOREIGN KEY(locked_block_id) REFERENCES locked_blocks (id) ON DELETE CASCADE,
-                    FOREIGN KEY(player_id) REFERENCES players (id) ON DELETE CASCADE
+                    FOREIGN KEY(locked_block_id) REFERENCES locked_blocks(id) ON DELETE CASCADE,
+                    FOREIGN KEY(player_id) REFERENCES players(id) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -218,8 +218,8 @@ public class DataService {
                     is_vertical BOOLEAN NOT NULL DEFAULT 0,
                     is_open BOOLEAN NOT NULL DEFAULT 0,
                     PRIMARY KEY(id),
-                    FOREIGN KEY(world_id) REFERENCES worlds (id) ON DELETE CASCADE,
-                    FOREIGN KEY(faction_id) REFERENCES factions (id) ON DELETE CASCADE
+                    FOREIGN KEY(world_id) REFERENCES worlds(id) ON DELETE CASCADE,
+                    FOREIGN KEY(faction_id) REFERENCES factions(id) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -228,8 +228,8 @@ public class DataService {
                     faction_id BINARY(16) NOT NULL,
                     invited_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     PRIMARY KEY(player_id, faction_id),
-                    FOREIGN KEY(player_id) REFERENCES players  (id) ON DELETE CASCADE,
-                    FOREIGN KEY(faction_id) REFERENCES factions (id) ON DELETE CASCADE
+                    FOREIGN KEY(player_id) REFERENCES players(id) ON DELETE CASCADE,
+                    FOREIGN KEY(faction_id) REFERENCES factions(id) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -239,8 +239,8 @@ public class DataService {
                     type TINYINT NOT NULL,
                     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     PRIMARY KEY(source_faction, target_faction),
-                    FOREIGN KEY(source_faction) REFERENCES factions (id) ON DELETE CASCADE,
-                    FOREIGN KEY(target_faction) REFERENCES factions (id) ON DELETE CASCADE
+                    FOREIGN KEY(source_faction) REFERENCES factions(id) ON DELETE CASCADE,
+                    FOREIGN KEY(target_faction) REFERENCES factions(id) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -249,7 +249,7 @@ public class DataService {
                     faction_id BINARY(16) NOT NULL,
                     text TEXT NOT NULL,
                     PRIMARY KEY(id),
-                    FOREIGN KEY(faction_id) REFERENCES factions (id) ON DELETE CASCADE
+                    FOREIGN KEY(faction_id) REFERENCES factions(id) ON DELETE CASCADE
                 )
             """);
         });

--- a/src/main/java/factionsplusplus/services/DataService.java
+++ b/src/main/java/factionsplusplus/services/DataService.java
@@ -114,8 +114,8 @@ public class DataService {
                     flag_name CHAR(255) NOT NULL,
                     `value` VARCHAR(255),
                     PRIMARY KEY(faction_id, flag_name),
-                    FOREIGN KEY(faction_id) REFERENCES factions ON DELETE CASCADE,
-                    FOREIGN KEY(flag_name) REFERENCES default_flags ON DELETE CASCADE
+                    FOREIGN KEY(faction_id) REFERENCES factions (id) ON DELETE CASCADE,
+                    FOREIGN KEY(flag_name) REFERENCES default_flags (name) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -130,8 +130,8 @@ public class DataService {
                     flag_name CHAR(255) NOT NULL,
                     `value` VARCHAR(255),
                     PRIMARY KEY(world_id, flag_name),
-                    FOREIGN KEY(world_id) REFERENCES worlds ON DELETE CASCADE,
-                    FOREIGN KEY(flag_name) REFERENCES default_flags ON DELETE CASCADE
+                    FOREIGN KEY(world_id) REFERENCES worlds (id) ON DELETE CASCADE,
+                    FOREIGN KEY(flag_name) REFERENCES default_flags (name) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -151,8 +151,8 @@ public class DataService {
                     player_id BINARY(16) NOT NULL,
                     role INTEGER NOT NULL DEFAULT 1,
                     PRIMARY KEY(faction_id, player_id),
-                    FOREIGN KEY(faction_id) REFERENCES factions ON DELETE CASCADE,
-                    FOREIGN KEY(player_id) REFERENCES players ON DELETE CASCADE
+                    FOREIGN KEY(faction_id) REFERENCES factions (id) ON DELETE CASCADE,
+                    FOREIGN KEY(player_id) REFERENCES players (id) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -162,8 +162,8 @@ public class DataService {
                     x_position INTEGER NOT NULL,
                     z_position INTEGER NOT NULL,
                     PRIMARY KEY(world_id, x_position, z_position),
-                    FOREIGN KEY(faction_id) REFERENCES factions ON DELETE CASCADE,
-                    FOREIGN KEY(world_id) REFERENCES worlds ON DELETE CASCADE
+                    FOREIGN KEY(faction_id) REFERENCES factions (id) ON DELETE CASCADE,
+                    FOREIGN KEY(world_id) REFERENCES worlds (id) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -176,8 +176,8 @@ public class DataService {
                     ended_at DATETIME,
                     is_active BOOLEAN NOT NULL DEFAULT 1,
                     PRIMARY KEY(id),
-                    FOREIGN KEY(attacker_id) REFERENCES factions ON DELETE CASCADE,
-                    FOREIGN KEY(defender_id) REFERENCES factions ON DELETE CASCADE
+                    FOREIGN KEY(attacker_id) REFERENCES factions (id) ON DELETE CASCADE,
+                    FOREIGN KEY(defender_id) REFERENCES factions (id) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -192,18 +192,18 @@ public class DataService {
                     allow_faction_members BOOLEAN NOT NULL DEFAULT 0,
                     PRIMARY KEY(id),
                     UNIQUE KEY UNIQUE_POSITION (world_id, x_position, y_position, z_position),
-                    FOREIGN KEY(world_id) REFERENCES worlds ON DELETE CASCADE,
-                    FOREIGN KEY(player_id) REFERENCES players ON DELETE CASCADE
-                )        
+                    FOREIGN KEY(world_id) REFERENCES worlds (id) ON DELETE CASCADE,
+                    FOREIGN KEY(player_id) REFERENCES players (id) ON DELETE CASCADE
+                )
             """);
             handle.execute("""
                 CREATE TABLE IF NOT EXISTS locked_block_access_list (
                     locked_block_id BINARY(16) NOT NULL,
                     player_id BINARY(16) NOT NULL,
                     PRIMARY KEY (locked_block_id, player_id),
-                    FOREIGN KEY(locked_block_id) REFERENCES locked_blocks ON DELETE CASCADE,
-                    FOREIGN KEY(player_id) REFERENCES players ON DELETE CASCADE
-                )        
+                    FOREIGN KEY(locked_block_id) REFERENCES locked_blocks (id) ON DELETE CASCADE,
+                    FOREIGN KEY(player_id) REFERENCES players (id) ON DELETE CASCADE
+                )
             """);
             handle.execute("""
                 CREATE TABLE IF NOT EXISTS faction_gates (
@@ -218,8 +218,8 @@ public class DataService {
                     is_vertical BOOLEAN NOT NULL DEFAULT 0,
                     is_open BOOLEAN NOT NULL DEFAULT 0,
                     PRIMARY KEY(id),
-                    FOREIGN KEY(world_id) REFERENCES worlds ON DELETE CASCADE,
-                    FOREIGN KEY(faction_id) REFERENCES factions ON DELETE CASCADE
+                    FOREIGN KEY(world_id) REFERENCES worlds (id) ON DELETE CASCADE,
+                    FOREIGN KEY(faction_id) REFERENCES factions (id) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -228,8 +228,8 @@ public class DataService {
                     faction_id BINARY(16) NOT NULL,
                     invited_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     PRIMARY KEY(player_id, faction_id),
-                    FOREIGN KEY(player_id) REFERENCES players ON DELETE CASCADE,
-                    FOREIGN KEY(faction_id) REFERENCES factions ON DELETE CASCADE
+                    FOREIGN KEY(player_id) REFERENCES players  (id) ON DELETE CASCADE,
+                    FOREIGN KEY(faction_id) REFERENCES factions (id) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -239,8 +239,8 @@ public class DataService {
                     type TINYINT NOT NULL,
                     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     PRIMARY KEY(source_faction, target_faction),
-                    FOREIGN KEY(source_faction) REFERENCES factions ON DELETE CASCADE,
-                    FOREIGN KEY(target_faction) REFERENCES factions ON DELETE CASCADE
+                    FOREIGN KEY(source_faction) REFERENCES factions (id) ON DELETE CASCADE,
+                    FOREIGN KEY(target_faction) REFERENCES factions (id) ON DELETE CASCADE
                 )
             """);
             handle.execute("""
@@ -249,7 +249,7 @@ public class DataService {
                     faction_id BINARY(16) NOT NULL,
                     text TEXT NOT NULL,
                     PRIMARY KEY(id),
-                    FOREIGN KEY(faction_id) REFERENCES factions ON DELETE CASCADE
+                    FOREIGN KEY(faction_id) REFERENCES factions (id) ON DELETE CASCADE
                 )
             """);
         });


### PR DESCRIPTION
Fixes an error when tables are creating as the referencing columns are not 1:1